### PR TITLE
fix logger timezones

### DIFF
--- a/src/sexpbot/plugins/logger.clj
+++ b/src/sexpbot/plugins/logger.clj
@@ -1,24 +1,30 @@
 (ns sexpbot.plugins.logger
   (:use [sexpbot respond]
-        [clj-time.core :only [now]]
+        [clj-time.core :only [now from-time-zone time-zone-for-offset]]
         [clj-time.format :only [unparse formatters]]
         [clojure.java.io :only [file]])
   (:import [java.io File]))
+
+(defn date-time [opts]
+  ;; What? Why doesn't clj-time let you unparse times in a timezone other than GMT?
+  (let [offset (or (:time-zone-offset opts) -6)
+        time   (from-time-zone (now) (time-zone-for-offset (- offset)))]
+    [(unparse (formatters :date) time)
+     (unparse (formatters :hour-minute-second) time)]))
 
 (defn log-message [{:keys [irc bot nick channel message action?]}]
   (let [config (:config @bot)
         server (:server @irc)
         last-channel (apply str (remove #(= % \#) channel))]
     (if (get-in config [server :log channel])
-      (let [log-dir  (file (:log-dir (config server)) server last-channel)
-            date     (unparse (formatters :date) (now))
-            time     (unparse (formatters :time) (now))
+      (let [[date time] (date-time config)
+            log-dir  (file (:log-dir (config server)) server last-channel)
             log-file (file log-dir (str date ".txt"))]
         (.mkdirs log-dir)
         (spit log-file
               (if action?
-                (format "[%s]: *%s %s\n" time nick message)
-                (format "[%s]: %s: %s\n" time nick message))
+                (format "[%s] *%s %s\n" time nick message)
+                (format "[%s] %s: %s\n" time nick message))
               :append true)))))
 
 (defplugin


### PR DESCRIPTION
i made the default be CST (-6) and added a config option `:time-zone-offset` so you can configure it.
