### PR TITLE
New Plugin: findfn

### DIFF
--- a/src/sexpbot/plugins/findfn.clj
+++ b/src/sexpbot/plugins/findfn.clj
@@ -1,0 +1,27 @@
+(ns sexpbot.plugins.findfn
+  (:use [sexpbot registry])
+  (:require [sexpbot.plugins.clojure :as sandbox]
+	    [clojure.string :as s]))
+
+(defn find-fn
+  [in out]
+  (map first (filter
+	       (fn [x]
+		 (try 
+		   (= out
+		      (binding [*out* java.io.StringWriter]
+			(apply
+			 (if (-> (second x) meta :macro)
+			   (macroexpand `(second x))
+			   (second x))
+			 in)))
+		   (catch Exception _ false)))
+	       (ns-publics (the-ns `clojure.core)))))
+
+(defplugin
+  (:cmd
+   "Finds the clojure fns, which given your input, produce your ouput."
+   #{"findfn"}
+   (fn [{:keys [bot args] :as com-m}]
+     (let [[user-in user-out :as args] (with-in-str (s/join " " args) [(read) (read)])]
+       (send-message com-m (str (vec (sandbox/sb `(find-fn ~user-in ~user-out)))))))))


### PR DESCRIPTION
The plugin finds functions based on their input and output. That means if you were to pass it [2 1] as an input and 3 as output it would let you know about + and some of the xor operators. Right now it only searches through clojure.core, but it would probably be pretty easy to expand its search.

ps: amalloy deserves any credit, I couldn't have done this without his help.
