### PR TITLE
adds support for fix-parens behaviour on eval

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,8 @@
                  [log4j "1.2.15" :exclusions [javax.mail/mail
                                               javax.jms/jms
                                               com.sun.jdmk/jmxtools
-                                              com.sun.jmx/jmxri]]]
+                                              com.sun.jmx/jmxri]]
+                 [fnparse "2.2.7"]]
   :dev-dependencies [[swank-clojure "1.2.1"]]
   :uberjar-name "sexpbot"
   :main sexpbot.run


### PR DESCRIPTION
creates a new fn ( sexpbot.plugins.clojure/safe-read-with-paren-fix ) that tries to safe-read the text, if it fails with EOF, it tries paren-fixing and reads again. 
