### PR TITLE
Removed info.clj items to fix default install

### DIFF
--- a/.lazybot/info.clj
+++ b/.lazybot/info.clj
@@ -1,7 +1,7 @@
 (let [plugins #{#_"dictionary" "lmgtfy" "google" "translate" "eball" "utils" "leet" "clojure" "login" "log"
-                "weather" "brainfuck" "whatis" "shorturl" "haskell"
+                "brainfuck" "whatis" "shorturl" "haskell"
                 "mail" "timer" "fortune" "rss" "title" "operator" "seen" "sed" "help"
-                "load" "embedded" "karma" "markov" "yesno" "autoreply"}]
+                "load" "embedded" "karma" "yesno" "autoreply"}]
   {:servers ["irc.freenode.net"]        ; A list of servers.
    :prepends #{"@"}   ; The character you want for a prepend. Currently set to @
    :bitly-login ""    ; Your bit.ly login.
@@ -26,7 +26,7 @@
                                "JaneDoe" {:pass "ohai", :privs :admin}}
                        :user-blacklist #{"Meowzorz"}
                        :autoreplies {"#clojure" {#".*(https?://)richhickey(.github.com/\S*).*" "Nooooo, that's so out of date! Please see instead $1clojure$2 and try to stop linking to rich's repo."}}
-                       :catch-links? {true} ; Should only be enabled if the title plugin is activated below.
+                       ;:catch-links? {true} ; Should only be enabled if the title plugin is activated below.
                        :channel-catch-blacklist #{} ; Channels in which URL title scraper is to be disabled.
                        :url-blacklist #{} ; URL title scraper will look for these words in URLs and not use them if they appear.
                        :user-ignore-url-blacklist [["bot" "ters"]] ; A series of "match this" but "not this" pairs.}


### PR DESCRIPTION
Couple simple changes to get the default install working.

The {true} line was blowing up as invalid syntax, and for whatever reason, the weather and markov plugins didn't work.

Removed plugins:
-weather
-markov

Commented out catch-links {true}
