### PR TITLE
Updates the javadoc base URL to the new docs.oracle.com domain.

### DIFF
--- a/src/lazybot/plugins/javadoc.clj
+++ b/src/lazybot/plugins/javadoc.clj
@@ -3,7 +3,7 @@
   (:require [clojure.string :as s]))
 
 (def ^{:dynamic true}
-  *javadoc-base-url* "http://download.oracle.com/javase/6/docs/api/")
+  *javadoc-base-url* "http://docs.oracle.com/javase/6/docs/api/")
 
 (defn format-varargs [class]
   (if-not (.isArray class)


### PR DESCRIPTION
I complained. Was told to fix it myself. Here it is. Enjoy :-)
