### PR TITLE
Restrict log4j imports to log plugin

### DIFF
--- a/src/lazybot/plugins/log.clj
+++ b/src/lazybot/plugins/log.clj
@@ -2,7 +2,12 @@
   (:use (lazybot registry utilities)
         [lazybot.plugins.login :only [when-privs]]
         clojure.tools.logging)
-  (:import [org.apache.log4j Level]))
+  (:import [org.apache.log4j Level LogManager]))
+
+(defn get-logger
+  ([] (get-logger (str *ns*)))
+  ([ns]
+     (LogManager/getLogger (str ns))))
 
 (defn str->package [s]
   (if (not= (.indexOf s ".") -1)

--- a/src/lazybot/utilities.clj
+++ b/src/lazybot/utilities.clj
@@ -2,8 +2,7 @@
   (:use lazybot.info
         [hobbit core isgd])
   (:require [clojure.string :only [join] :as string])
-  (:import [java.io File FileReader]
-           [org.apache.log4j LogManager]))
+  (:import [java.io File FileReader]))
 
 ;; ## Pretty time formatting
 ;; This is a bit ugly. Each entry in the table describes how many of the
@@ -59,11 +58,6 @@
   semantics instead of those of (future)."
   [& body]
   `(.start (Thread. (fn [] ~@body))))
-
-(defn get-logger
-  ([] (get-logger (str *ns*)))
-  ([ns]
-     (LogManager/getLogger (str ns))))
 
 (defn split-str-at [len s]
   (map #(apply str %)


### PR DESCRIPTION
When using lazybot with non-log4j logging, this fix allows laybot core to work, and
restricts breakage to the log plugin
