### PR TITLE
updated hobbit lib to not use a snapshot

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [org.clojure/data.zip "0.1.0"]
                  [org.clojure/tools.cli "0.1.0"]
                  [useful "0.7.2"]
-                 [hobbit "0.1.0-20111019.122151-5"]
+                 [hobbit "0.1.0-alpha1"]
                  [ororo "0.1.0"]
                  [socrates "0.0.1"]
                  [innuendo "0.1.1"]]


### PR DESCRIPTION
This is to fix [issue #67](https://github.com/flatland/lazybot/issues/67)
