### PR TITLE
Fix invalid url, generated by clojuredocs command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs
 logs
 *log
 .cake
+target

--- a/src/lazybot/plugins/clojuredocs.clj
+++ b/src/lazybot/plugins/clojuredocs.clj
@@ -11,7 +11,7 @@
      (send-message
       com-m
       (if-let [results (seq (take 5 (apply cd/search args)))]
-        (join "; " (for [{:keys [url ns name]} (reverse (sort-by :id results))]
+        (join "  " (for [{:keys [url ns name]} (reverse (sort-by :id results))]
                      (format "%s/%s: %s" ns name url)))
         "No results found."))))
 


### PR DESCRIPTION
Some IRC client have problems with urls, generated by clojuredocs command. So they include semicolon to url when higlighting like here: [http://clojuredocs.org/v/43;](http://clojuredocs.org/v/43;) E.g. pidgin and xchat do this. I think it's better to ommit semicolon or separate it from actual url by 1 space.
