### PR TITLE
Sort log files in descending order.

### DIFF
--- a/src/lazybot/plugins/logger.clj
+++ b/src/lazybot/plugins/logger.clj
@@ -112,9 +112,9 @@
       (list
         [:h1 "Logs for " channel " on " server]
         [:ol
-         (map (fn [log]
-                [:li (link log server channel log)])
-              logs)]))))
+         (->> logs
+              (sort (fn [a b] (compare b a)))
+              (map (fn [log] [:li (link log server channel log)])))]))))
 
 (defn server-index
   "A hiccup doc describing logs on a server."


### PR DESCRIPTION
Log files for IRC-channels aren't sorted, and the result is that it is hard to find the date you're looking for. This pull request sort the log files in descending order (newest date first), based on the assumption that every file is on the form `yyyy-mm-dd.txt`.
