### PR TITLE
Get seen case insensitive

### DIFF
--- a/src/lazybot/plugins/seen.clj
+++ b/src/lazybot/plugins/seen.clj
@@ -11,13 +11,13 @@
   "Takes a nick and updates the seen database with that nick and the current time."
   [nick server channel doing]
   (let [lower-nick (.toLowerCase nick)]
-    (destroy! :seen {:nick nick :server server})
+    (destroy! :seen {:nick lower-nick :server server})
     (insert! :seen
              {:server server
               :time (now)
               :chan channel 
               :doing doing
-              :nick nick})))
+              :nick lower-nick})))
 
 (defn get-seen
   "Gets the last-seen for a nick."


### PR DESCRIPTION
lazybot doesn't convert nicks to lowercase whenever it looks up and updates nicknames. This pull request convert nicknames to lowercase before storing and updating them.

Note that this doesn't automatically convert nicks already stored, so proper removal of nicks should be done if one really cares about the correctness of this plugin.
