### PR TITLE
Update title plugin to listen on any message event

### DIFF
--- a/src/lazybot/plugins/title.clj
+++ b/src/lazybot/plugins/title.clj
@@ -65,7 +65,7 @@
 
 (registry/defplugin
   (:hook
-   :on-message
+   :privmsg
    (fn [{:keys [network bot nick channel message] :as com-m}]
      (let [info (:config @bot)
            get-links (fn [s]


### PR DESCRIPTION
There was an update that `:on-message` was substituted by `:privmsg` and this is the last plugin that is using the old event.