### PR TITLE
allow mongo db config to be a map

### DIFF
--- a/src/lazybot/core.clj
+++ b/src/lazybot/core.clj
@@ -22,11 +22,14 @@
 (defn initiate-mongo
   "Initiate the mongodb connection and set it globally."
   []
-  (try
-    (mongo! :db (or (:db (info/read-config)) "lazybot"))
-    (catch Throwable e
-      (println "Error starting mongo (see below), carrying on without it")
-      (.printStackTrace e))))
+  (let [dbconf (:db (info/read-config))]
+    (try
+      (cond
+        (map? dbconf) (mongo! :db (or (:db dbconf) "lazybot") :host (or (:host dbconf) "localhost") :port (or (:port dbconf) 27017))
+        :else (mongo! :db (or dbconf "lazybot")))
+      (catch Throwable e
+        (println "Error starting mongo (see below), carrying on without it")
+        (.printStackTrace e)))))
 
 (defn call-all
   "Call all hooks of a specific type."


### PR DESCRIPTION
I was trying to run lazybot in a docker container and needed to be able to specify a different host for the mongo service.  This works, but I'm new to clojure, so if there's a better way please let me know.

Thanks.