### PR TITLE
support running with docker/fig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM clojure
+
+COPY .  /app
+WORKDIR /app
+
+RUN lein deps
+
+COPY .lazybot/ /root/.lazybot
+COPY example.policy /root/.java.policy

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,7 @@
+bot:
+  build: .
+  command: lein run
+  links:
+   - mongo
+mongo:
+  image: mongo:2


### PR DESCRIPTION
This change enables running lazybot in docker via [fig](http://www.fig.sh/).  Just put the config you want in `.lazybot/config.clj` and then run `fig up` and two containers are created, one for lazybot and one for mongo.

(sorry for the flurry of pull requests, this is the last one for the day) :wink: