### PR TITLE
Rework to pull Grimoire ns listing from site

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [hiccup "1.0.2"]
                  [me.raynes/least "0.1.3"]
                  [me.raynes/moments "0.1.1"]
-                 [org.clojure-grimoire/lib-grimoire "0.1.1"]]
+                 [org.clojure-grimoire/lib-grimoire "0.9.0-alpha2"]]
   :uberjar-name "lazybot.jar"
   :main lazybot.run
   :copy-deps true

--- a/src/lazybot/plugins/grimoire.clj
+++ b/src/lazybot/plugins/grimoire.clj
@@ -5,6 +5,7 @@
             [grimoire.api :as api]
             [grimoire.api.web :as web]
             [grimoire.api.web.read]
+            [lazybot.plugins.login :refer [when-privs]]
             [lazybot.registry :refer [defplugin send-message]]))
 
 (def -config
@@ -45,9 +46,10 @@
    "Reload the Grimoire ns index"
    #{"reload-grim"}
    (fn [com-m]
-     (->> (try (do (set-def-index!)
-                   (format "Reload succeeded!, %d defs indexed."
-                           (count @def-index)))
-               (catch Exception e
-                 (str "Reload failed!" (.getMessage e))))
-          (send-message com-m)))))
+     (when-privs com-m :admin
+       (->> (try (do (set-def-index!)
+                     (format "Reload succeeded!, %d defs indexed."
+                             (count @def-index)))
+                 (catch Exception e
+                   (str "Reload failed!" (.getMessage e))))
+            (send-message com-m))))))

--- a/src/lazybot/plugins/grimoire.clj
+++ b/src/lazybot/plugins/grimoire.clj
@@ -1,43 +1,53 @@
 (ns lazybot.plugins.grimoire
   (:require [grimoire.util :as util]
+            [grimoire.things :as t]
+            [grimoire.either :as e]
+            [grimoire.api :as api]
+            [grimoire.api.web :as web]
+            [grimoire.api.web.read]
             [lazybot.registry :refer [defplugin send-message]]))
 
-(def nss #{"clojure.core"
-           "clojure.core.protocols"
-           "clojure.core.reducers"
-           "clojure.data"
-           "clojure.edn"
-           "clojure.inspector"
-           "clojure.instant"
-           "clojure.java.browse"
-           "clojure.java.io"
-           "clojure.java.javadoc"
-           "clojure.java.shell"
-           "clojure.main"
-           "clojure.pprint"
-           "clojure.reflect"
-           "clojure.repl"
-           "clojure.set"
-           "clojure.stacktrace"
-           "clojure.string"
-           "clojure.template"
-           "clojure.test"
-           "clojure.test.junit"
-           "clojure.test.tap"
-           "clojure.uuid"
-           "clojure.walk"
-           "clojure.xml"
-           "clojure.zip"})
+(def -config
+  (web/->Config "http://conj.io"))
+
+(def def-index
+  (atom {}))
+
+(defn set-def-index! []
+  (let [group (t/->Group "org.clojure")]
+    (->> (for [artifact     (e/result (api/list-artifacts -config group))
+               :let [newest (first (e/result (api/list-versions -config artifact)))]
+               platform     (e/result (api/list-platforms -config newest))
+               ns           (e/result (api/list-namespaces -config platform))
+               def          (e/result (api/list-defs -config ns))]
+           [(str (t/thing->name platform) "::" (t/thing->name ns) "/" (t/thing->name def)) def])
+         (into {})
+         (reset! def-index))))
+
+(set-def-index!)
 
 (defplugin
   (:cmd
    "Print the Grimoire URL for a symbol"
    #{"grim"}
    (fn [{:keys [args] :as com-m}]
-     (let [sym      (first args)
-           [_ ns s] (re-matches #"(.*?)/(.*)" sym)]
-       (when (nss ns)
-         (send-message
-          com-m
-          (format "http://grimoire.arrdem.com/1.6.0/%s/%s"
-                  ns (util/munge s))))))))
+     (let [sym                   (first args)
+           [sym key platform ns s] (re-matches #"((.+)::(.+))/(.+)" sym)]
+       (->> (if (and platform ns s)
+              (if-let [def (get @def-index sym)]
+                (str "⇒ " (web/make-html-url -config def))
+                (str "Failed to find " sym))
+              (str "Identify a def with <platform>::<namespace>/<name>"))
+            (send-message com-m)))))
+
+  ;; FIXME: this should probably be ratelimited
+  (:cmd
+   "Reload the Grimoire ns index"
+   #{"reload-grim"}
+   (fn [com-m]
+     (->> (try (do (set-def-index!)
+                   (format "Reload succeeded!, %d defs indexed."
+                           (count @def-index)))
+               (catch Exception e
+                 (str "Reload failed!" (.getMessage e))))
+          (send-message com-m)))))


### PR DESCRIPTION
This patch removes the fixed list of documented namespaces in
clojure.core, and replaces it with a dynamically generated list of all
the namespaces in the latest version of Clojure on Grimoire.

This still doesn't fix the underlying issue of not being able to match
arbitrary symbols to documentation URLs, but `clojure.core` is pretty
much the only thing on Grimoire right now so we'll go with this as a
start.

**PR NOT READY TO MERGE** depends on unreleased lib-grimoire version. I'll ping when this is ready.
