### PR TITLE
Allow server password and SSL options

### DIFF
--- a/src/lazybot/irc.clj
+++ b/src/lazybot/irc.clj
@@ -45,13 +45,17 @@
   [server]
   (let [bot-config (info/read-config)
         port (get-in bot-config [server :port] 6667)
-        [name pass channels] ((juxt :bot-name :bot-password :channels)
-                                   (bot-config server))
+        ssl? (get-in bot-config [server :port] false)
+        [name pass nickserv-pass channels] ((juxt
+                                             :bot-name :server-password :bot-password :channels)
+                                            (bot-config server))
         [fnmap refzors] (base-maps bot-config)
         irc (ircb/connect server port name
                           :callbacks fnmap
+                          :pass pass
+                          :ssl? ssl?
                           :identify-after-secs 3)]
-    (ircb/identify irc pass)
+    (ircb/identify irc nickserv-pass)
     [irc refzors]))
 
 (defn init-bot


### PR DESCRIPTION
I'm using the bot on a private IRC server, couldn't connect to it without this patch. The server requires a password and SSL, which previously were not passed down to irclj.
